### PR TITLE
Changing Pylint broken link in testing2 tutorial

### DIFF
--- a/2021-03-25-iss/section-resources-from-presentations.md
+++ b/2021-03-25-iss/section-resources-from-presentations.md
@@ -31,7 +31,7 @@
   * Python Build and Test Framework: [pyscaffold.org](https://pyscaffold.org)
   * Build-Link-Test CMake Framework: [llnl-blt.readthedocs.io](https://llnl-blt.readthedocs.io)
   * Static Source Analysis (C++): [clang-tidy](https://clang.llvm.org/extra/clang-tidy/)
-  * Static Source Analysis (python): [flake8](https://flake8.pycqa.org/en/latest/index.html) and [pylint](https://www.pylint.org/)
+  * Static Source Analysis (python): [flake8](https://flake8.pycqa.org/en/latest/index.html) and [pylint](https://pylint.pycqa.org/en/latest/) *(updated 2022-03-31 due to dead link)*
   * Code Coverage Webservices: [codecov](https://about.codecov.io/) and [coveralls](https://coveralls.io/)
   * Tutorials for code coverage: [Online Tutorial](https://github.com/amklinv/morpheus), [Another example](https://github.com/jrdoneal/infrastructure)
   * [Development Practices Survey Article](https://dx.doi.org/10.6084/m9.figshare.14188463.v1)

--- a/2021-04-12-ecpam/section-resources-from-presentations.md
+++ b/2021-04-12-ecpam/section-resources-from-presentations.md
@@ -17,7 +17,7 @@
   * Python Build and Test Framework: [pyscaffold.org](https://pyscaffold.org)
   * Build-Link-Test CMake Framework: [llnl-blt.readthedocs.io](https://llnl-blt.readthedocs.io)
   * Static Source Analysis (C++): [clang-tidy](https://clang.llvm.org/extra/clang-tidy/)
-  * Static Source Analysis (python): [flake8](https://flake8.pycqa.org/en/latest/index.html) and [pylint](https://www.pylint.org/)
+  * Static Source Analysis (python): [flake8](https://flake8.pycqa.org/en/latest/index.html) and [pylint](https://pylint.pycqa.org/en/latest/) *(updated 2022-03-31 due to dead link)*
   * Code Coverage Webservices: [codecov](https://about.codecov.io/) and [coveralls](https://coveralls.io/)
   * Tutorials for code coverage: [Online Tutorial](https://github.com/amklinv/morpheus), [Another example](https://github.com/jrdoneal/infrastructure)
   * [Development Practices Survey Article](https://dx.doi.org/10.6084/m9.figshare.14188463.v1)

--- a/2021-06-24-isc/section-resources-from-presentations.md
+++ b/2021-06-24-isc/section-resources-from-presentations.md
@@ -69,7 +69,7 @@
   * Python Build and Test Framework: [pyscaffold.org](https://pyscaffold.org)
   * Build-Link-Test CMake Framework: [llnl-blt.readthedocs.io](https://llnl-blt.readthedocs.io)
   * Static Source Analysis (C++): [clang-tidy](https://clang.llvm.org/extra/clang-tidy/)
-  * Static Source Analysis (python): [flake8](https://flake8.pycqa.org/en/latest/index.html) and [pylint](https://www.pylint.org/)
+  * Static Source Analysis (python): [flake8](https://flake8.pycqa.org/en/latest/index.html) and [pylint](https://pylint.pycqa.org/en/latest/) *(updated 2022-03-31 due to dead link)*
   * Code Coverage Webservices: [codecov](https://about.codecov.io/) and [coveralls](https://coveralls.io/)
   * Tutorials for code coverage: [Online Tutorial](https://github.com/amklinv/morpheus), [Another example](https://github.com/jrdoneal/infrastructure)
   * [Development Practices Survey Article](https://dx.doi.org/10.6084/m9.figshare.14188463.v1)

--- a/2021-08-12-atpesc/presentation-resources/testing-introduction.md
+++ b/2021-08-12-atpesc/presentation-resources/testing-introduction.md
@@ -3,7 +3,7 @@
   * Python Build and Test Framework: [pyscaffold.org](https://pyscaffold.org)
   * Build-Link-Test CMake Framework: [llnl-blt.readthedocs.io](https://llnl-blt.readthedocs.io)
   * Static Source Analysis (C++): [clang-tidy](https://clang.llvm.org/extra/clang-tidy/)
-  * Static Source Analysis (python): [flake8](https://flake8.pycqa.org/en/latest/index.html) and [pylint](https://www.pylint.org/)
+  * Static Source Analysis (python): [flake8](https://flake8.pycqa.org/en/latest/index.html) and [pylint](https://pylint.pycqa.org/en/latest/) *(updated 2022-03-31 due to dead link)*
   * Code Coverage Webservices: [codecov](https://about.codecov.io/) and [coveralls](https://coveralls.io/)
   * Tutorials for code coverage: [Online Tutorial](https://github.com/amklinv/morpheus), [Another example](https://github.com/jrdoneal/infrastructure)
   * [Development Practices Survey Article](https://dx.doi.org/10.6084/m9.figshare.14188463.v1)

--- a/2021-11-15-sc/presentation-resources/testing-introduction2.md
+++ b/2021-11-15-sc/presentation-resources/testing-introduction2.md
@@ -3,7 +3,7 @@
   * Python Build and Test Framework: [pyscaffold.org](https://pyscaffold.org)
   * Build-Link-Test CMake Framework: [llnl-blt.readthedocs.io](https://llnl-blt.readthedocs.io)
   * Static Source Analysis (C++): [clang-tidy](https://clang.llvm.org/extra/clang-tidy/)
-  * Static Source Analysis (python): [flake8](https://flake8.pycqa.org/en/latest/index.html) and [pylint](https://www.pylint.org/)
+  * Static Source Analysis (python): [flake8](https://flake8.pycqa.org/en/latest/index.html) and [pylint](https://pylint.pycqa.org/en/latest/) *(updated 2022-03-31 due to dead link)*
   * Code Coverage Webservices: [codecov](https://about.codecov.io/) and [coveralls](https://coveralls.io/)
   * Tutorials for code coverage: [Online Tutorial](https://github.com/amklinv/morpheus), [Another example](https://github.com/jrdoneal/infrastructure)
   * [Development Practices Survey Article](https://dx.doi.org/10.6084/m9.figshare.14188463.v1)

--- a/2022-04-07-iss/presentation-resources/testing-introduction2.md
+++ b/2022-04-07-iss/presentation-resources/testing-introduction2.md
@@ -3,7 +3,7 @@
   * Python Build and Test Framework: [pyscaffold.org](https://pyscaffold.org)
   * Build-Link-Test CMake Framework: [llnl-blt.readthedocs.io](https://llnl-blt.readthedocs.io)
   * Static Source Analysis (C++): [clang-tidy](https://clang.llvm.org/extra/clang-tidy/)
-  * Static Source Analysis (python): [flake8](https://flake8.pycqa.org/en/latest/index.html) and [pylint](https://www.pylint.org/)
+  * Static Source Analysis (python): [flake8](https://flake8.pycqa.org/en/latest/index.html) and [pylint](https://pylint.pycqa.org/en/latest/)
   * Code Coverage Webservices: [codecov](https://about.codecov.io/) and [coveralls](https://coveralls.io/)
   * Tutorials for code coverage: [Online Tutorial](https://github.com/amklinv/morpheus), [Another example](https://github.com/jrdoneal/infrastructure)
   * [Development Practices Survey Article](https://dx.doi.org/10.6084/m9.figshare.14188463.v1)

--- a/2022-04-07-iss/presentation-resources/testing-introduction2.md
+++ b/2022-04-07-iss/presentation-resources/testing-introduction2.md
@@ -11,5 +11,3 @@
   * CMake [add-test](https://cmake.org/cmake/help/latest/command/add_test.html) command documentation
   * [Verification and Validation in Scientific Computing](https://doi.org/10.1017/CBO9780511760396)
   * [Working Effectively with Legacy Code](https://doi.org/10.1007/978-3-540-27777-4_42)
-
-


### PR DESCRIPTION
Pylint has  a broken link. The new link is https://pylint.pycqa.org/en/latest/